### PR TITLE
Add OLD to the DELETE notification

### DIFF
--- a/resources/migrations/20161105154847-events-table.up.sql
+++ b/resources/migrations/20161105154847-events-table.up.sql
@@ -8,6 +8,7 @@ BEGIN
  -- TG_TABLE_NAME - name of the table that was triggered
  -- TG_OP - name of the trigger operation
  -- NEW - the new value in the row
+ -- OLD - the old value in the row
  IF TG_OP = 'INSERT' or TG_OP = 'UPDATE' THEN
    execute 'NOTIFY '
    || TG_TABLE_NAME
@@ -21,6 +22,8 @@ BEGIN
    || TG_TABLE_NAME
    || ', '''
    || TG_OP
+   || ' '
+   || OLD
    || '''';
  END IF;
  return new;


### PR DESCRIPTION
This way we can remove the event for example from the list in the frontend.
Without this information, we only "DELETE " without information about what is deleted.
Another issu, is when deleting many row we get only one event in the frontend. With this fix we get all deleted rows events.

NB : May be Postgres dont send notification with same message many times.